### PR TITLE
Add publish workflow for tag releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag matches Cargo.toml version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version=$(sed -n -E "s/^version[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/p" Cargo.toml | head -n 1)
+          if [[ -z "${version}" ]]; then
+            echo "Failed to read version from Cargo.toml" >&2
+            exit 1
+          fi
+          stripped_tag="${tag#v}"
+          if [[ "${stripped_tag}" != "${version}" ]]; then
+            echo "Tag (${tag}) does not match Cargo.toml version (${version})" >&2
+            exit 1
+          fi
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATE_TOKEN }}
+        run: cargo publish


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish on tag push
- verify tag matches Cargo.toml version before publish

## Notes
- uses repository secret `CRATE_TOKEN` for cargo publish